### PR TITLE
feat(seo): add sitemap.xml and robots.txt generation

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next'
 
-const SITE_URL = 'https://podoswroclaw.pl'
+import { SITE_URL } from '@/config/site'
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,9 +1,10 @@
 import type { MetadataRoute } from 'next'
 
-const SITE_URL = 'https://podoswroclaw.pl'
+import { i18n } from '@/config/i18n'
+import { SITE_URL } from '@/config/site'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const locales = ['pl', 'ua'] as const
+  const { locales } = i18n
   const now = new Date()
 
   const localeEntries: MetadataRoute.Sitemap = locales.map((locale) => ({

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,1 @@
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://podoswroclaw.pl'


### PR DESCRIPTION
## Summary
- Adds `app/sitemap.ts` — generates `/sitemap.xml` with `/`, `/pl`, `/ua` routes (weekly changeFrequency, priority 1.0)
- Adds `app/robots.ts` — allows all crawlers, disallows `/admin` and `/api`, references sitemap URL

## Why
Site `podoswroclaw.pl` is live. Without sitemap, Google may miss pages or index them slower.

## Test plan
- [ ] Verify `/sitemap.xml` returns valid XML with correct URLs
- [ ] Verify `/robots.txt` returns correct directives
- [ ] Build passes without errors

Closes #8

Made with [Cursor](https://cursor.com)