### PR TITLE
feat(cms): add on-demand revalidation via Payload hooks

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,23 @@
+import { revalidatePath } from 'next/cache'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  const secret = request.headers.get('x-revalidation-secret')
+
+  if (!process.env.REVALIDATION_SECRET) {
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
+
+  if (secret !== process.env.REVALIDATION_SECRET) {
+    return NextResponse.json({ error: 'Invalid secret' }, { status: 401 })
+  }
+
+  try {
+    revalidatePath('/pl', 'page')
+    revalidatePath('/ua', 'page')
+
+    return NextResponse.json({ revalidated: ['/pl', '/ua'], now: Date.now() })
+  } catch {
+    return NextResponse.json({ error: 'Revalidation failed' }, { status: 500 })
+  }
+}

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -55,7 +55,7 @@ export async function getServices(locale: Locale): Promise<ServicesData | null> 
     const url = `${API_URL}/api/services?where[locale][equals]=${locale}&limit=1`
 
     const res = await fetch(url, {
-      next: { revalidate: 60 }, // Revalidate every minute
+      next: { revalidate: false },
     })
 
     if (!res.ok) return null
@@ -74,7 +74,7 @@ export async function getServices(locale: Locale): Promise<ServicesData | null> 
 export async function getCertificates(locale: Locale): Promise<CertificatesData | null> {
   try {
     const res = await fetch(`${API_URL}/api/certificates?where[locale][equals]=${locale}&limit=1&depth=2`, {
-      next: { revalidate: 60 },
+      next: { revalidate: false },
     })
 
     if (!res.ok) return null

--- a/src/payload/collections/Certificates.ts
+++ b/src/payload/collections/Certificates.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
+import { revalidateAfterChange } from '../hooks/revalidateContent'
+
 export const Certificates: CollectionConfig = {
   slug: 'certificates',
   admin: {
@@ -9,6 +11,9 @@ export const Certificates: CollectionConfig = {
   },
   access: {
     read: () => true,
+  },
+  hooks: {
+    afterChange: [revalidateAfterChange],
   },
   fields: [
     {

--- a/src/payload/collections/Services.ts
+++ b/src/payload/collections/Services.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
+import { revalidateAfterChange } from '../hooks/revalidateContent'
+
 export const Services: CollectionConfig = {
   slug: 'services',
   admin: {
@@ -8,7 +10,10 @@ export const Services: CollectionConfig = {
     group: 'Content',
   },
   access: {
-    read: () => true, // Public read access
+    read: () => true,
+  },
+  hooks: {
+    afterChange: [revalidateAfterChange],
   },
   fields: [
     {

--- a/src/payload/hooks/revalidateContent.ts
+++ b/src/payload/hooks/revalidateContent.ts
@@ -1,0 +1,9 @@
+import { revalidatePath } from 'next/cache'
+import type { CollectionAfterChangeHook } from 'payload'
+
+export const revalidateAfterChange: CollectionAfterChangeHook = ({ doc }) => {
+  revalidatePath('/pl', 'page')
+  revalidatePath('/ua', 'page')
+  console.log(`[revalidate] Pages /pl and /ua revalidated`)
+  return doc
+}


### PR DESCRIPTION
## Summary
- Replace time-based ISR (`revalidate: 60`) with on-demand revalidation using `revalidatePath`
- Add `afterChange` hooks to Services and Certificates collections — pages `/pl` and `/ua` revalidate instantly when CMS content is updated
- Add `POST /api/revalidate` endpoint (secured with `REVALIDATION_SECRET` header) for manual/external triggers

## Changes
| File | Change |
|------|--------|
| `src/lib/payload.ts` | `revalidate: 60` → `revalidate: false` (cache until manually invalidated) |
| `app/api/revalidate/route.ts` | New POST endpoint with secret auth |
| `src/payload/hooks/revalidateContent.ts` | `afterChange` hook calling `revalidatePath` |
| `src/payload/collections/Services.ts` | Hook wired up |
| `src/payload/collections/Certificates.ts` | Hook wired up |

## Env
Add `REVALIDATION_SECRET` to production env (only needed for the API route, hooks work without it).

## Test plan
- [ ] Edit service in CMS → changes appear instantly on `/pl` and `/ua`
- [ ] Edit certificate in CMS → changes appear instantly
- [ ] `POST /api/revalidate` with correct secret returns 200
- [ ] `POST /api/revalidate` with wrong/missing secret returns 401
- [ ] Build passes

Closes #9

Made with [Cursor](https://cursor.com)