### PR TITLE
fix(csp): allow Google Maps embed in frame-src directive

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,7 +19,7 @@ const nextConfig: NextConfig = {
               "img-src 'self' data: https: blob:",
               "font-src 'self' data:",
               "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://analytics.google.com",
-              "frame-src 'self' https://www.googletagmanager.com",
+              "frame-src 'self' https://www.googletagmanager.com https://www.google.com https://maps.google.com",
               "object-src 'none'",
               "base-uri 'self'",
               "form-action 'self'",


### PR DESCRIPTION
## Summary

- Add `https://www.google.com` and `https://maps.google.com` to CSP `frame-src` directive to allow Google Maps iframe embeds

## Root cause

The Content-Security-Policy header in `next.config.ts` only allowed `'self'` and `googletagmanager.com` in `frame-src`, blocking Google Maps embeds in production.

Closes #23

Made with [Cursor](https://cursor.com)