### PR TITLE
fix(csp): allow Google Fonts in font-src and style-src

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,9 +15,9 @@ const nextConfig: NextConfig = {
             value: [
               "default-src 'self'",
               "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com",
-              "style-src 'self' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "img-src 'self' data: https: blob:",
-              "font-src 'self' data:",
+              "font-src 'self' data: https://fonts.gstatic.com",
               "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://analytics.google.com",
               "frame-src 'self' https://www.googletagmanager.com https://www.google.com https://maps.google.com",
               "object-src 'none'",


### PR DESCRIPTION
## Summary

- Add `https://fonts.gstatic.com` to CSP `font-src` directive
- Add `https://fonts.googleapis.com` to CSP `style-src` directive

## Root cause

Google Fonts were blocked by Content-Security-Policy on production, causing font loading errors in console.

Closes #27

Made with [Cursor](https://cursor.com)