### PR TITLE
release: sync CSP Google Fonts fix to production

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,9 +15,9 @@ const nextConfig: NextConfig = {
             value: [
               "default-src 'self'",
               "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com",
-              "style-src 'self' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "img-src 'self' data: https: blob:",
-              "font-src 'self' data:",
+              "font-src 'self' data: https://fonts.gstatic.com",
               "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://analytics.google.com",
               "frame-src 'self' https://www.googletagmanager.com https://www.google.com https://maps.google.com",
               "object-src 'none'",


### PR DESCRIPTION
Add Google Fonts domains to CSP font-src and style-src directives. Closes #27

Made with [Cursor](https://cursor.com)