### PR TITLE
fix(middleware): exclude sitemap.xml and robots.txt from locale redirect

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -27,5 +27,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|admin|_next/static|_next/image|images|media|favicon.ico).*)'],
+  matcher: ['/((?!api|admin|_next/static|_next/image|images|media|favicon.ico|sitemap.xml|robots.txt).*)'],
 }


### PR DESCRIPTION
## Summary
- Middleware was redirecting `/sitemap.xml` → `/pl/sitemap.xml` and `/robots.txt` → `/pl/robots.txt`, breaking SEO crawling
- Added `sitemap.xml` and `robots.txt` to the middleware matcher exclusion list

## Context
Needed for Google Search Console setup — sitemap submission requires `/sitemap.xml` to be accessible without locale redirect.

## Test plan
- [ ] `https://podoswroclaw.pl/sitemap.xml` returns XML without redirect
- [ ] `https://podoswroclaw.pl/robots.txt` returns plain text without redirect
- [ ] Locale routing still works for all other paths

Made with [Cursor](https://cursor.com)