### PR TITLE
fix(config): strip trailing slash from SITE_URL to prevent double slashes

### DIFF
--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,1 +1,1 @@
-export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://podoswroclaw.pl'
+export const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://podoswroclaw.pl').replace(/\/$/, '')


### PR DESCRIPTION
## Summary
- `SITE_URL` with a trailing slash caused double slashes in sitemap URLs, canonical links, and other SEO metadata (e.g. `https://domain.pl//ua`)
- Added `.replace(/\/$/, '')` to strip trailing slash from the env variable

## Context
Follow-up to PR #33. The double slash issue was spotted on `dev.podoswroclaw.pl/sitemap.xml`.

## Test plan
- [ ] `/sitemap.xml` URLs have no double slashes
- [ ] Canonical and OG URLs are correct

Made with [Cursor](https://cursor.com)