### PR TITLE
perf(hero): preload hero images and add skeleton background-color

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -31,6 +31,24 @@ export default async function Page({ params }: HomePageProps) {
 
   return (
     <>
+      <link
+        rel='preload'
+        as='image'
+        imageSrcSet='/images/sections/hero/bg-mob.webp 1x, /images/sections/hero/bg-mob@2x.webp 2x'
+        media='(max-width: 479px)'
+      />
+      <link
+        rel='preload'
+        as='image'
+        imageSrcSet='/images/sections/hero/bg-tabl.webp 1x, /images/sections/hero/bg-tabl@2x.webp 2x'
+        media='(min-width: 480px) and (max-width: 991px)'
+      />
+      <link
+        rel='preload'
+        as='image'
+        imageSrcSet='/images/sections/hero/bg-desc.webp 1x, /images/sections/hero/bg-desc@2x.webp 2x'
+        media='(min-width: 992px)'
+      />
       <LangSetter locale={locale} />
       <main>
         <HomePage locale={locale} />

--- a/src/sections/Hero/Hero.module.scss
+++ b/src/sections/Hero/Hero.module.scss
@@ -23,6 +23,7 @@
   position: relative;
   padding: 34px 25px;
   height: 745px;
+  background-color: #e0cdc0;
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;


### PR DESCRIPTION
## Summary
- Add responsive `<link rel="preload">` with `imageSrcSet` for hero background images — browser starts downloading during HTML parsing, before CSS is parsed
- Add `background-color: #e0cdc0` as skeleton placeholder matching the hero image tone

## Context
PageSpeed Insights: LCP = 2.9s (orange). Hero background-image is discovered late because the browser must download and parse CSS before finding it. Preload hints allow parallel download.

Closes #36

## Test plan
- [ ] Hero section renders identically to before
- [ ] Skeleton background-color visible briefly before image loads (throttle network to verify)
- [ ] No layout shift or visual regression
- [ ] Check PageSpeed Insights LCP after deploy

Made with [Cursor](https://cursor.com)