### PR TITLE
feat(analytics): add Vercel Analytics for cookie-free page view tracking

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { GoogleAnalytics } from '@/components/GoogleAnalytics'
 import { AnalyticsPageView } from '@/components/AnalyticsPageView'
 import { GOOGLE_TAG_MANAGER_ID, isAnalyticsEnabled } from '@/constants/analytics'
 import { SpeedInsights } from '@vercel/speed-insights/next'
+import { Analytics } from '@vercel/analytics/next'
 import { CookieConsent } from '@/components/CookieConsent'
 import { Suspense } from 'react'
 
@@ -28,6 +29,7 @@ export default function LocaleLayout({ children }: { children: React.ReactNode }
           </>
         )}
         <SpeedInsights />
+        <Analytics />
         {children}
         {isAnalyticsEnabled() && GOOGLE_TAG_MANAGER_ID && <CookieConsent />}
       </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@payloadcms/next": "^3.75.0",
         "@payloadcms/richtext-lexical": "^3.75.0",
         "@types/classnames": "^2.3.0",
+        "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^1.2.0",
         "classnames": "^2.5.1",
         "graphql": "^16.12.0",
@@ -4547,6 +4548,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/speed-insights": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@payloadcms/next": "^3.75.0",
     "@payloadcms/richtext-lexical": "^3.75.0",
     "@types/classnames": "^2.3.0",
+    "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^1.2.0",
     "classnames": "^2.5.1",
     "graphql": "^16.12.0",


### PR DESCRIPTION
## Summary
- Install `@vercel/analytics` and add `<Analytics />` component to locale layout
- Provides cookie-free, GDPR-compliant baseline page view tracking alongside existing GTM + SpeedInsights

## Test plan
- [ ] Verify Vercel Analytics dashboard shows page views after deploy
- [ ] Confirm no cookies are set by the analytics script
- [ ] Confirm no interference with GTM or SpeedInsights

Closes #32

Made with [Cursor](https://cursor.com)