### PR TITLE
perf(images): add sizes attribute to Image component for proper image selection

### DIFF
--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -15,28 +15,38 @@ export type ImageProps = {
   width: number
   height: number
   loading?: 'lazy' | 'eager'
+  sizes?: string
   className?: string
 }
 
-export const Image = ({ src, alt, width, height, loading = 'lazy', className }: ImageProps) => {
+export const Image = ({ src, alt, width, height, loading = 'lazy', sizes, className }: ImageProps) => {
   const isString = typeof src === 'string'
   const hasExtension = isString ? /\.(png|jpg|jpeg|webp)$/i.test(src) : false
   const normalize = (value?: string) => (value && value.length > 0 ? value : undefined)
+  const useWidthDescriptors = !!sizes
 
   const webpSrcSet = isString
     ? hasExtension
       ? undefined
-      : `${src}@2x.webp 2x, ${src}.webp 1x`
+      : useWidthDescriptors
+        ? `${src}.webp ${width}w, ${src}@2x.webp ${width * 2}w`
+        : `${src}@2x.webp 2x, ${src}.webp 1x`
     : src.webp1x
-      ? `${normalize(src.webp2x) ?? src.webp1x} 2x, ${src.webp1x} 1x`
+      ? useWidthDescriptors
+        ? `${src.webp1x} ${width}w${normalize(src.webp2x) ? `, ${src.webp2x} ${width * 2}w` : ''}`
+        : `${normalize(src.webp2x) ?? src.webp1x} 2x, ${src.webp1x} 1x`
       : undefined
 
   const pngSrcSet = isString
     ? hasExtension
       ? undefined
-      : `${src}@2x.png 2x, ${src}.png 1x`
+      : useWidthDescriptors
+        ? `${src}.png ${width}w, ${src}@2x.png ${width * 2}w`
+        : `${src}@2x.png 2x, ${src}.png 1x`
     : src.png1x
-      ? `${normalize(src.png2x) ?? src.png1x} 2x, ${src.png1x} 1x`
+      ? useWidthDescriptors
+        ? `${src.png1x} ${width}w${normalize(src.png2x) ? `, ${src.png2x} ${width * 2}w` : ''}`
+        : `${normalize(src.png2x) ?? src.png1x} 2x, ${src.png1x} 1x`
       : undefined
 
   const imgSrc = isString
@@ -50,8 +60,8 @@ export const Image = ({ src, alt, width, height, loading = 'lazy', className }: 
   return (
     <div className={cx(styles.image, className)}>
       <picture>
-        {webpSrcSet && <source srcSet={webpSrcSet} type='image/webp' />}
-        <img src={imgSrc} srcSet={pngSrcSet} alt={alt} loading={loading} width={width} height={height} />
+        {webpSrcSet && <source srcSet={webpSrcSet} type='image/webp' sizes={sizes} />}
+        <img src={imgSrc} srcSet={pngSrcSet} sizes={sizes} alt={alt} loading={loading} width={width} height={height} />
       </picture>
     </div>
   )

--- a/src/sections/About/index.tsx
+++ b/src/sections/About/index.tsx
@@ -35,6 +35,7 @@ export const AboutSection = ({ locale }: AboutSectionProps) => {
             alt={t.alt}
             width={590}
             height={700}
+            sizes='(max-width: 991px) calc(100vw - 40px), 590px'
             className={styles.contentImage}
           />
         </div>


### PR DESCRIPTION
## Summary
- Add optional `sizes` prop to the custom `<Image>` component
- When `sizes` is provided, switch from density descriptors (`1x`/`2x`) to width descriptors (`w`), enabling the browser to pick the optimal image based on viewport width + device pixel ratio
- Add `sizes` to About section image — resolves PageSpeed "Properly size images" warning (~142 KiB savings on 1x displays)

## Test plan
- [ ] Verify About image renders correctly on desktop and mobile
- [ ] Inspect `<source>` and `<img>` tags — should have `sizes` and `srcSet` with width descriptors
- [ ] Run PageSpeed Insights — "Properly size images" warning should be resolved
- [ ] Existing images without `sizes` prop still use density descriptors (no regression)

Closes #37

Made with [Cursor](https://cursor.com)