### PR TITLE
fix(seo): resolve Google Search Console indexing issues

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -9,6 +9,8 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 import { Analytics } from '@vercel/analytics/next'
 import { CookieConsent } from '@/components/CookieConsent'
 import { Suspense } from 'react'
+import { type Locale } from '@/config/i18n'
+import { getLangCode } from '@/config/locales'
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -16,9 +18,18 @@ export const viewport: Viewport = {
   viewportFit: 'cover',
 }
 
-export default function LocaleLayout({ children }: { children: React.ReactNode }) {
+export default async function LocaleLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ locale: string }>
+}) {
+  const { locale: rawLocale } = await params
+  const locale = rawLocale as Locale
+
   return (
-    <html suppressHydrationWarning>
+    <html lang={getLangCode(locale)} suppressHydrationWarning>
       <body className={poppins.variable}>
         {isAnalyticsEnabled() && GOOGLE_TAG_MANAGER_ID && (
           <>

--- a/app/not-found.module.scss
+++ b/app/not-found.module.scss
@@ -1,0 +1,41 @@
+@use '@/styles/abstracts' as *;
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  font-family: $font-primary;
+  text-align: center;
+  padding: 2rem;
+}
+
+.title {
+  font-size: clamp(4rem, 10vw, 8rem);
+  font-weight: 700;
+  color: $color-accent-primary;
+  margin: 0;
+}
+
+.description {
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  color: $color-text-secondary;
+  margin-top: 0.5rem;
+}
+
+.link {
+  margin-top: 2rem;
+  padding: 0.75rem 2rem;
+  background-color: $color-accent-primary;
+  color: $color-white;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 1rem;
+  text-decoration: none;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 0.85;
+  }
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+import '@/styles/globals.scss'
+import { poppins } from '@/styles/fonts'
+import styles from './not-found.module.scss'
+
+export default function NotFound() {
+  return (
+    <html lang='pl'>
+      <body className={poppins.variable}>
+        <div className={styles.wrapper}>
+          <h1 className={styles.title}>404</h1>
+          <p className={styles.description}>Strona nie została znaleziona</p>
+          <Link href='/pl' className={styles.link}>
+            Strona główna
+          </Link>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -8,7 +8,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/admin', '/api'],
+        disallow: ['/admin', '/api', '/_next/static/'],
       },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,26 +1,28 @@
 import type { MetadataRoute } from 'next'
 
 import { i18n } from '@/config/i18n'
+import { getLangCode } from '@/config/locales'
 import { SITE_URL } from '@/config/site'
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const { locales } = i18n
   const now = new Date()
 
-  const localeEntries: MetadataRoute.Sitemap = locales.map((locale) => ({
+  const alternateLanguages = locales.reduce(
+    (acc, locale) => {
+      acc[getLangCode(locale)] = `${SITE_URL}/${locale}`
+      return acc
+    },
+    { 'x-default': `${SITE_URL}/${i18n.defaultLocale}` } as Record<string, string>
+  )
+
+  return locales.map((locale) => ({
     url: `${SITE_URL}/${locale}`,
     lastModified: now,
-    changeFrequency: 'weekly',
-    priority: 1.0,
-  }))
-
-  return [
-    {
-      url: SITE_URL,
-      lastModified: now,
-      changeFrequency: 'weekly',
-      priority: 1.0,
+    changeFrequency: 'weekly' as const,
+    priority: locale === i18n.defaultLocale ? 1.0 : 0.8,
+    alternates: {
+      languages: alternateLanguages,
     },
-    ...localeEntries,
-  ]
+  }))
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,7 +12,7 @@ export function middleware(request: NextRequest) {
   }
 
   if (pathname === '/') {
-    return NextResponse.redirect(new URL(`/${i18n.defaultLocale}`, request.url))
+    return NextResponse.redirect(new URL(`/${i18n.defaultLocale}`, request.url), 301)
   }
 
   const pathnameIsMissingLocale = i18n.locales.every(
@@ -20,7 +20,7 @@ export function middleware(request: NextRequest) {
   )
 
   if (pathnameIsMissingLocale) {
-    return NextResponse.redirect(new URL(`/${i18n.defaultLocale}${pathname}`, request.url))
+    return NextResponse.redirect(new URL(`/${i18n.defaultLocale}${pathname}`, request.url), 301)
   }
 
   return NextResponse.next()

--- a/src/config/locales.ts
+++ b/src/config/locales.ts
@@ -2,6 +2,7 @@ export {
   localeRegistry,
   localeCodes,
   defaultLocaleCode,
+  getLangCode,
   type LocaleEntry,
   type LocaleCode,
 } from '../payload/locale-registry'

--- a/src/payload/locale-registry.ts
+++ b/src/payload/locale-registry.ts
@@ -1,5 +1,7 @@
 export type LocaleEntry = {
   readonly code: string
+  /** ISO 639-1 language code for HTML lang and hreflang attributes */
+  readonly langCode: string
   readonly label: string
   readonly nativeLabel: string
 }
@@ -9,10 +11,13 @@ export type LocaleEntry = {
  *   1. Add an entry here
  *   2. Create translation JSON files in src/translations/<code>/
  *   3. Rebuild
+ *
+ * `code` — URL slug (used in routes like /pl, /ua)
+ * `langCode` — ISO 639-1 code (used for <html lang>, hreflang, sitemap)
  */
 export const localeRegistry = [
-  { code: 'pl', label: 'Polish', nativeLabel: 'Polski' },
-  { code: 'ua', label: 'Ukrainian', nativeLabel: 'Українська' },
+  { code: 'pl', langCode: 'pl', label: 'Polish', nativeLabel: 'Polski' },
+  { code: 'ua', langCode: 'uk', label: 'Ukrainian', nativeLabel: 'Українська' },
 ] as const
 
 export type LocaleCode = (typeof localeRegistry)[number]['code']
@@ -20,3 +25,9 @@ export type LocaleCode = (typeof localeRegistry)[number]['code']
 export const localeCodes: LocaleCode[] = [...localeRegistry.map((l) => l.code)]
 
 export const defaultLocaleCode: LocaleCode = 'pl'
+
+const codeLangMap = Object.fromEntries(localeRegistry.map((l) => [l.code, l.langCode])) as Record<LocaleCode, string>
+
+export function getLangCode(code: LocaleCode): string {
+  return codeLangMap[code]
+}

--- a/src/utils/generateMetadata.ts
+++ b/src/utils/generateMetadata.ts
@@ -1,14 +1,13 @@
 import { Metadata } from 'next'
 import { Locale } from '@/config/i18n'
-import { localeCodes, defaultLocaleCode } from '@/config/locales'
+import { localeCodes, defaultLocaleCode, getLangCode } from '@/config/locales'
+import { SITE_URL } from '@/config/site'
 import { translations } from '@/translations'
-
-const SITE_URL = 'https://podoswroclaw.pl'
 
 function buildAlternateLanguages(): Record<string, string> {
   const langs: Record<string, string> = {}
   for (const code of localeCodes) {
-    langs[code] = `${SITE_URL}/${code}`
+    langs[getLangCode(code)] = `${SITE_URL}/${code}`
   }
   langs['x-default'] = `${SITE_URL}/${defaultLocaleCode}`
   return langs


### PR DESCRIPTION
## Summary

Fixes all SEO indexing issues reported by Google Search Console (404s, redirects, uncrawled pages).

- **Sitemap**: removed root URL that caused redirect loop, added hreflang alternates (`pl`, `uk`, `x-default`) for proper multilingual support
- **Middleware**: changed all redirects from 307 (temporary) to 301 (permanent) so Google follows them correctly
- **hreflang**: fixed language code from invalid `ua` to ISO 639-1 `uk` for Ukrainian — in both `<head>` meta and sitemap
- **HTML lang**: added `<html lang>` attribute to locale layout (`pl` / `uk`)
- **robots.txt**: blocked `/_next/static/` to prevent Google from crawling font files
- **404 page**: added custom `not-found.tsx` with proper `<html>`/`<body>` tags (previously threw Runtime Error)
- **Metadata**: use `SITE_URL` from config instead of hardcoded value

## GSC Issues Addressed

| Issue | Pages | Fix |
|-------|-------|-----|
| Not found (404) | 3 (old image URLs) | Custom 404 page renders properly |
| Page with redirect | 2 (`/` → `/pl`) | Removed from sitemap, 307→301 |
| Crawled — not indexed | 5 (4 fonts + `/ua/`) | Block fonts in robots.txt, fix hreflang + lang attr |

## Test plan

- [ ] Verify `curl localhost:3000/sitemap.xml` returns XML with hreflang `pl`, `uk`, `x-default`
- [ ] Verify `curl localhost:3000/robots.txt` blocks `/_next/static/`
- [ ] Verify `/pl/nonexistent` shows custom 404 page (not Runtime Error)
- [ ] Verify `curl -I localhost:3000/` returns 301 redirect
- [ ] Verify `<html lang="pl">` on `/pl` and `<html lang="uk">` on `/ua`
- [ ] Build passes (`npm run build`)

Closes #46

Made with [Cursor](https://cursor.com)