### PR TITLE
chore(analytics): restrict all analytics and metrics to production only

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -2,13 +2,7 @@ import type { Viewport } from 'next'
 
 import '@/styles/globals.scss'
 import { poppins } from '@/styles/fonts'
-import { GoogleAnalytics } from '@/components/GoogleAnalytics'
-import { AnalyticsPageView } from '@/components/AnalyticsPageView'
-import { GOOGLE_TAG_MANAGER_ID, isAnalyticsEnabled } from '@/constants/analytics'
-import { SpeedInsights } from '@vercel/speed-insights/next'
-import { Analytics } from '@vercel/analytics/next'
-import { CookieConsent } from '@/components/CookieConsent'
-import { Suspense } from 'react'
+import { ProductionAnalytics } from '@/components/ProductionAnalytics'
 import { type Locale } from '@/config/i18n'
 import { getLangCode } from '@/config/locales'
 
@@ -31,18 +25,8 @@ export default async function LocaleLayout({
   return (
     <html lang={getLangCode(locale)} suppressHydrationWarning>
       <body className={poppins.variable}>
-        {isAnalyticsEnabled() && GOOGLE_TAG_MANAGER_ID && (
-          <>
-            <GoogleAnalytics gtmId={GOOGLE_TAG_MANAGER_ID} />
-            <Suspense fallback={null}>
-              <AnalyticsPageView />
-            </Suspense>
-          </>
-        )}
-        <SpeedInsights />
-        <Analytics />
+        <ProductionAnalytics />
         {children}
-        {isAnalyticsEnabled() && GOOGLE_TAG_MANAGER_ID && <CookieConsent />}
       </body>
     </html>
   )

--- a/src/components/ProductionAnalytics/index.tsx
+++ b/src/components/ProductionAnalytics/index.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react'
+import { SpeedInsights } from '@vercel/speed-insights/next'
+import { Analytics } from '@vercel/analytics/next'
+import { GoogleAnalytics } from '@/components/GoogleAnalytics'
+import { AnalyticsPageView } from '@/components/AnalyticsPageView'
+import { CookieConsent } from '@/components/CookieConsent'
+import { GOOGLE_TAG_MANAGER_ID, isProductionDeployment } from '@/constants/analytics'
+
+export function ProductionAnalytics() {
+  if (!isProductionDeployment) return null
+
+  return (
+    <>
+      {GOOGLE_TAG_MANAGER_ID && (
+        <>
+          <GoogleAnalytics gtmId={GOOGLE_TAG_MANAGER_ID} />
+          <Suspense fallback={null}>
+            <AnalyticsPageView />
+          </Suspense>
+          <CookieConsent />
+        </>
+      )}
+      <SpeedInsights />
+      <Analytics />
+    </>
+  )
+}

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -1,5 +1,8 @@
 export const GOOGLE_TAG_MANAGER_ID = process.env.NEXT_PUBLIC_GTM_ID
 
+export const isProductionDeployment =
+  process.env.VERCEL_ENV === 'production' || (process.env.NODE_ENV === 'production' && !process.env.VERCEL_ENV)
+
 export const isAnalyticsEnabled = () => {
   return (
     GOOGLE_TAG_MANAGER_ID &&


### PR DESCRIPTION
## Summary

- Extract all analytics (GTM, GA page views, cookie consent, Vercel Speed Insights, Vercel Analytics) into a single `ProductionAnalytics` component
- Only render on production deployments (checks `VERCEL_ENV === 'production'`)
- Cleans up layout — removes 7 imports, replaces conditional blocks with one component

## Test plan

- [ ] Verify no analytics scripts load on localhost
- [ ] Verify no analytics scripts load on Vercel preview deployments
- [ ] Verify all analytics work on production deployment


Made with [Cursor](https://cursor.com)