### PR TITLE
fix(header): use dvh units for mobile menu to prevent content clipping

### DIFF
--- a/src/sections/Header/components/MobileMenu/MobileMenu.module.scss
+++ b/src/sections/Header/components/MobileMenu/MobileMenu.module.scss
@@ -13,7 +13,7 @@
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  height: 100dvh;
   background: rgba(0, 0, 0, 0.5);
   z-index: 999;
   animation: fadeIn 0.3s ease-in-out;
@@ -24,7 +24,7 @@
   top: 0;
   right: 0;
   width: min(320px, 80vw);
-  height: 100vh;
+  height: 100dvh;
   background: white;
   z-index: 1000;
   box-shadow: -2px 0 10px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- Replace `100vh` with `100dvh` in mobile menu `.backdrop` and `.menu` classes
- Fixes bottom content (language switcher, contact icons) being hidden behind mobile browser chrome (address bar, bottom navigation) on real devices

## Test plan
- [ ] Open mobile menu on a real iOS/Android device
- [ ] Verify language switcher and contact icons are visible at the bottom
- [ ] Verify menu scrolls if content overflows


Made with [Cursor](https://cursor.com)