### PR TITLE
perf: reduce unused JS via dynamic imports and remove react-hook-form

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,9 @@ const nextConfig: NextConfig = {
   compress: true,
   poweredByHeader: false,
   generateEtags: false,
+  experimental: {
+    optimizePackageImports: ['@vercel/analytics', '@vercel/speed-insights'],
+  },
   async headers() {
     return [
       {
@@ -18,7 +21,7 @@ const nextConfig: NextConfig = {
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "img-src 'self' data: https: blob:",
               "font-src 'self' data: https://fonts.gstatic.com",
-              "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://analytics.google.com",
+              "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://analytics.google.com https://api.web3forms.com",
               "frame-src 'self' https://www.googletagmanager.com https://www.google.com https://maps.google.com",
               "object-src 'none'",
               "base-uri 'self'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "payload": "^3.75.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-hook-form": "^7.60.0",
         "sharp": "^0.34.5",
         "swiper": "^11.2.10"
       },
@@ -10838,22 +10837,6 @@
       },
       "peerDependencies": {
         "react": ">=16.13.1"
-      }
-    },
-    "node_modules/react-hook-form": {
-      "version": "7.71.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
-      "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/react-hook-form"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-image-crop": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "payload": "^3.75.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.60.0",
     "sharp": "^0.34.5",
     "swiper": "^11.2.10"
   },

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FieldValues, useForm } from 'react-hook-form'
+import { useState, type FormEvent } from 'react'
 import { Locale } from '@/config/i18n'
 import plTranslations from '@/translations/pl/form.json'
 import uaTranslations from '@/translations/ua/form.json'
@@ -11,57 +11,75 @@ const translations = {
   ua: uaTranslations,
 } as const
 
+type FormFields = {
+  name: string
+  phone: string
+  email: string
+  message: string
+}
+
+type FormErrors = Partial<Record<keyof FormFields, string>>
+
 type FormProps = {
   locale: Locale
-  onSubmit: (data: FieldValues, reset: () => void) => Promise<void>
+  onSubmit: (data: FormFields, reset: () => void) => Promise<void>
 }
+
+const initialValues: FormFields = { name: '', phone: '', email: '', message: '' }
 
 export const Form = ({ locale, onSubmit }: FormProps) => {
   const t = translations[locale]
+  const [values, setValues] = useState<FormFields>(initialValues)
+  const [errors, setErrors] = useState<FormErrors>({})
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors },
-  } = useForm({
-    defaultValues: {
-      name: '',
-      phone: '',
-      email: '',
-      message: '',
-    },
-  })
+  const validate = (): boolean => {
+    const next: FormErrors = {}
+    if (!values.name.trim()) next.name = 'Name is required'
+    if (!values.phone.trim()) next.phone = 'Phone is required'
+    if (!values.email.trim()) next.email = 'Email is required'
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  const reset = () => {
+    setValues(initialValues)
+    setErrors({})
+  }
+
+  const handleChange = (field: keyof FormFields) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setValues((prev) => ({ ...prev, [field]: e.target.value }))
+    if (errors[field]) setErrors((prev) => ({ ...prev, [field]: undefined }))
+  }
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    if (validate()) onSubmit(values, reset)
+  }
 
   return (
-    <form className={styles.form} onSubmit={handleSubmit((data) => onSubmit(data, reset))}>
+    <form className={styles.form} onSubmit={handleSubmit}>
       <label className={styles.label} htmlFor='name'>
         <span className={styles.required}>{t.name}</span>
-        <p className={styles.error}>{errors.name?.message as string}</p>
+        <p className={styles.error}>{errors.name}</p>
       </label>
-      <input className={styles.input} id='name' type='text' {...register('name', { required: 'Name is required' })} />
+      <input className={styles.input} id='name' type='text' value={values.name} onChange={handleChange('name')} />
 
       <label className={styles.label} htmlFor='phone'>
         <span className={styles.required}>{t.phone}</span>
-        <p className={styles.error}>{errors.phone?.message as string}</p>
+        <p className={styles.error}>{errors.phone}</p>
       </label>
-      <input className={styles.input} id='phone' type='tel' {...register('phone', { required: 'Phone is required' })} />
+      <input className={styles.input} id='phone' type='tel' value={values.phone} onChange={handleChange('phone')} />
 
       <label className={styles.label} htmlFor='email'>
         <span className={styles.required}>{t.email}</span>
-        <p className={styles.error}>{errors.email?.message as string}</p>
+        <p className={styles.error}>{errors.email}</p>
       </label>
-      <input
-        className={styles.input}
-        id='email'
-        type='email'
-        {...register('email', { required: 'Email is required' })}
-      />
+      <input className={styles.input} id='email' type='email' value={values.email} onChange={handleChange('email')} />
 
       <label className={styles.label} htmlFor='message'>
         {t.message}
       </label>
-      <textarea className={styles.textarea} id='message' {...register('message', { required: false })} />
+      <textarea className={styles.textarea} id='message' value={values.message} onChange={handleChange('message')} />
 
       <button className={styles.submitButton} type='submit'>
         {t.submitButton}

--- a/src/sections/Certificates/index.tsx
+++ b/src/sections/Certificates/index.tsx
@@ -1,9 +1,11 @@
+import dynamic from 'next/dynamic'
 import { Container } from '@/components/Container'
 import styles from './Certificates.module.scss'
 import { Locale } from '@/config/i18n'
 import { getCertificates, type CertificateItem } from '@/lib/payload'
-import { CertificatesList } from './components/CertificatesList'
 import { HeaderContent } from './components/HeaderContent'
+
+const CertificatesList = dynamic(() => import('./components/CertificatesList').then((m) => m.CertificatesList))
 
 type CertificatesSectionProps = {
   locale: Locale

--- a/src/sections/Footer/components/ContactForm/ContactForm.client.tsx
+++ b/src/sections/Footer/components/ContactForm/ContactForm.client.tsx
@@ -3,7 +3,6 @@
 import { Form } from '@/components/Form'
 import { Locale } from '@/config/i18n'
 import { useState } from 'react'
-import { FieldValues } from 'react-hook-form'
 import { Notification } from '@/components/Notification'
 import { analytics } from '@/utils/analytics'
 import plTranslations from '@/translations/pl/form.json'
@@ -30,11 +29,11 @@ export const ContactFormClient = ({ locale }: ContactFormClientProps) => {
   const [showNotification, setShowNotification] = useState(false)
   const [isSuccess, setIsSuccess] = useState(false)
 
-  const onSubmit = async (data: FieldValues, reset: () => void) => {
+  const onSubmit = async (data: Record<string, string>, reset: () => void) => {
     try {
       const formData = new FormData()
       Object.entries(data).forEach(([key, value]) => {
-        formData.append(key, value as string)
+        formData.append(key, value)
       })
 
       formData.append('access_key', API_KEY)
@@ -49,7 +48,6 @@ export const ContactFormClient = ({ locale }: ContactFormClientProps) => {
         setShowNotification(true)
         reset()
 
-        // Track successful form submission
         analytics.trackFormSubmission('contact_form', true)
       } else {
         throw new Error('Form submission failed')

--- a/src/sections/Footer/components/ContactForm/ContactForm.server.tsx
+++ b/src/sections/Footer/components/ContactForm/ContactForm.server.tsx
@@ -1,10 +1,12 @@
+import dynamic from 'next/dynamic'
 import { Locale } from '@/config/i18n'
 import styles from './ContactForm.module.scss'
 import { Paragraph } from '@/components/TextContent/Paragraph'
 import plTranslations from '@/translations/pl/footer.json'
 import uaTranslations from '@/translations/ua/footer.json'
 import { HeaderContent } from '@/components/TextContent/HeaderContent'
-import { ContactFormClient } from './ContactForm.client'
+
+const ContactFormClient = dynamic(() => import('./ContactForm.client').then((m) => m.ContactFormClient))
 
 const translations = {
   pl: plTranslations,

--- a/src/sections/Works/index.tsx
+++ b/src/sections/Works/index.tsx
@@ -1,9 +1,11 @@
+import dynamic from 'next/dynamic'
 import { Container } from '@/components/Container'
 import { Locale } from '@/config/i18n'
 import { getWorks, type WorkItem } from '@/lib/payload'
 import { HeaderContent } from './components/HeaderContent'
-import { WorksList } from './components/WorksList'
 import styles from './Works.module.scss'
+
+const WorksList = dynamic(() => import('./components/WorksList').then((m) => m.WorksList))
 
 type WorksSectionProps = {
   locale: Locale


### PR DESCRIPTION
## Summary
- Dynamic import for CertificatesList and WorksList (Swiper) — moved below-fold sliders to lazy-loaded chunks
- Dynamic import for ContactFormClient — footer form loaded on demand
- Replaced react-hook-form (~40KB) with native useState for 4-field contact form
- Added `optimizePackageImports` for Vercel analytics packages
- Fixed CSP: allow `connect-src` to `api.web3forms.com` (pre-existing bug)

## Test plan
- [ ] Verify sliders (Certificates, Works) render correctly on scroll
- [ ] Verify contact form submits successfully
- [ ] Verify form validation works (empty required fields)
- [ ] Run PageSpeed Insights and compare "Remove unused JavaScript" metric
- [ ] Check no layout shift when lazy components load

Closes #13

Made with [Cursor](https://cursor.com)