### PR TITLE
feat: add Telegram notifications for contact form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Analytics
+NEXT_PUBLIC_ENABLE_ANALYTICS="true"
+NEXT_PUBLIC_GA_ID=""
+NEXT_PUBLIC_GTM_ID=""
+WEB3FORMS_API_KEY=""
+
+# Telegram notifications
+TELEGRAM_BOT_TOKEN=""
+TELEGRAM_CHAT_ID=""
+
+# Payload CMS
+DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=verify-full"
+PAYLOAD_SECRET="your-secret-key-at-least-32-characters-long"
+NEXT_PUBLIC_SERVER_URL="http://localhost:3000"

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server'
+
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID
+const WEB3FORMS_API_KEY = process.env.WEB3FORMS_API_KEY
+
+type ContactForm = {
+  name: string
+  phone: string
+  email: string
+  message?: string
+}
+
+function formatTelegramMessage({ name, phone, email, message }: ContactForm): string {
+  const lines = [
+    `<b>Nova wiadomość z formularza PodOS</b>`,
+    ``,
+    `<b>Imię:</b> ${escapeHtml(name)}`,
+    `<b>Telefon:</b> ${escapeHtml(phone)}`,
+    `<b>Email:</b> ${escapeHtml(email)}`,
+  ]
+
+  if (message?.trim()) {
+    lines.push(`<b>Wiadomość:</b> ${escapeHtml(message)}`)
+  }
+
+  return lines.join('\n')
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+async function sendTelegram(form: ContactForm): Promise<boolean> {
+  if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) return false
+
+  const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chat_id: TELEGRAM_CHAT_ID,
+      text: formatTelegramMessage(form),
+      parse_mode: 'HTML',
+    }),
+    signal: AbortSignal.timeout(10000),
+  })
+
+  return res.ok
+}
+
+async function sendWeb3Forms(form: ContactForm): Promise<boolean> {
+  if (!WEB3FORMS_API_KEY) return false
+
+  const formData = new FormData()
+  formData.append('access_key', WEB3FORMS_API_KEY)
+  formData.append('name', form.name)
+  formData.append('phone', form.phone)
+  formData.append('email', form.email)
+  if (form.message) formData.append('message', form.message)
+
+  const res = await fetch('https://api.web3forms.com/submit', {
+    method: 'POST',
+    body: formData,
+    signal: AbortSignal.timeout(10000),
+  })
+
+  return res.ok
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as ContactForm
+
+    if (!body.name?.trim() || !body.phone?.trim() || !body.email?.trim()) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
+    }
+
+    const [telegramOk, emailOk] = await Promise.allSettled([sendTelegram(body), sendWeb3Forms(body)]).then((results) =>
+      results.map((r) => r.status === 'fulfilled' && r.value)
+    )
+
+    if (!telegramOk && !emailOk) {
+      return NextResponse.json({ error: 'Failed to send message' }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,7 +22,7 @@ const nextConfig: NextConfig = {
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "img-src 'self' data: https: blob:",
               "font-src 'self' data: https://fonts.gstatic.com",
-              "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://analytics.google.com https://api.web3forms.com",
+              "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://analytics.google.com",
               "frame-src 'self' https://www.googletagmanager.com https://www.google.com https://maps.google.com",
               "object-src 'none'",
               "base-uri 'self'",

--- a/src/sections/Footer/components/ContactForm/ContactForm.client.tsx
+++ b/src/sections/Footer/components/ContactForm/ContactForm.client.tsx
@@ -18,12 +18,6 @@ const translations = {
   ua: uaTranslations,
 } as const
 
-const API_KEY = process.env.NEXT_PUBLIC_WEB3FORMS_API_KEY!
-
-if (!process.env.NEXT_PUBLIC_WEB3FORMS_API_KEY) {
-  console.error('NEXT_PUBLIC_WEB3FORMS_API_KEY is not set')
-}
-
 export const ContactFormClient = ({ locale }: ContactFormClientProps) => {
   const t = translations[locale]
   const [showNotification, setShowNotification] = useState(false)
@@ -31,16 +25,10 @@ export const ContactFormClient = ({ locale }: ContactFormClientProps) => {
 
   const onSubmit = async (data: Record<string, string>, reset: () => void) => {
     try {
-      const formData = new FormData()
-      Object.entries(data).forEach(([key, value]) => {
-        formData.append(key, value)
-      })
-
-      formData.append('access_key', API_KEY)
-
-      const response = await fetch('https://api.web3forms.com/submit', {
+      const response = await fetch('/api/contact', {
         method: 'POST',
-        body: formData,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
       })
 
       if (response.ok) {


### PR DESCRIPTION
Closes #64

## Summary
- Add `/api/contact` server route that sends form submissions to Telegram and Web3Forms in parallel
- Move Web3Forms API key from client-side (`NEXT_PUBLIC_`) to server-side env var
- Remove `api.web3forms.com` from CSP connect-src (now server-side only)
- Telegram bot sends formatted messages to group "PodOS Notifications"

## Test plan
- [x] Tested locally — messages arrive in Telegram group
- [x] Web3Forms email fallback works
- [x] No secrets in source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)