### PR TITLE
feat: make email field optional in contact form

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -7,7 +7,7 @@ const WEB3FORMS_API_KEY = process.env.WEB3FORMS_API_KEY
 type ContactForm = {
   name: string
   phone: string
-  email: string
+  email?: string
   message?: string
 }
 
@@ -17,8 +17,11 @@ function formatTelegramMessage({ name, phone, email, message }: ContactForm): st
     ``,
     `<b>Imię:</b> ${escapeHtml(name)}`,
     `<b>Telefon:</b> ${escapeHtml(phone)}`,
-    `<b>Email:</b> ${escapeHtml(email)}`,
   ]
+
+  if (email?.trim()) {
+    lines.push(`<b>Email:</b> ${escapeHtml(email)}`)
+  }
 
   if (message?.trim()) {
     lines.push(`<b>Wiadomość:</b> ${escapeHtml(message)}`)
@@ -55,7 +58,7 @@ async function sendWeb3Forms(form: ContactForm): Promise<boolean> {
   formData.append('access_key', WEB3FORMS_API_KEY)
   formData.append('name', form.name)
   formData.append('phone', form.phone)
-  formData.append('email', form.email)
+  if (form.email) formData.append('email', form.email)
   if (form.message) formData.append('message', form.message)
 
   const res = await fetch('https://api.web3forms.com/submit', {
@@ -71,7 +74,7 @@ export async function POST(request: Request) {
   try {
     const body = (await request.json()) as ContactForm
 
-    if (!body.name?.trim() || !body.phone?.trim() || !body.email?.trim()) {
+    if (!body.name?.trim() || !body.phone?.trim()) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
     }
 

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -36,7 +36,6 @@ export const Form = ({ locale, onSubmit }: FormProps) => {
     const next: FormErrors = {}
     if (!values.name.trim()) next.name = 'Name is required'
     if (!values.phone.trim()) next.phone = 'Phone is required'
-    if (!values.email.trim()) next.email = 'Email is required'
     setErrors(next)
     return Object.keys(next).length === 0
   }
@@ -71,7 +70,7 @@ export const Form = ({ locale, onSubmit }: FormProps) => {
       <input className={styles.input} id='phone' type='tel' value={values.phone} onChange={handleChange('phone')} />
 
       <label className={styles.label} htmlFor='email'>
-        <span className={styles.required}>{t.email}</span>
+        {t.email}
         <p className={styles.error}>{errors.email}</p>
       </label>
       <input className={styles.input} id='email' type='email' value={values.email} onChange={handleChange('email')} />


### PR DESCRIPTION
## Summary
- Make email field optional — phone is the primary contact method
- Telegram notifications don't require email to reach the client
- Email kept as optional field for those who prefer it

## Test plan
- [ ] Submit form with only name + phone — should succeed
- [ ] Submit form with all fields — should succeed
- [ ] Telegram message shows email only when provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)